### PR TITLE
Updated nette/utils dependency for PHP 8.4+ compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 		"contributte/application": "^0.5.0",
 		"nette/di": "^3.0.0",
 		"nette/forms": "^3.1.3",
-		"nette/utils": "^3.0.1",
+		"nette/utils": "^3.0.1 || ^4.0",
 		"symfony/property-access": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Nette/utils 3 is deprecated and no longer compatible with the latest PHP version. 

Version 4 dropped support for PHP 7 and updated type annotations. Otherwise it should be backwards compatible with version 3. 